### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-sketch.yml
+++ b/.github/workflows/lint-sketch.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint-sketches:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Leffell-Space/LightAPRS-Code/security/code-scanning/1](https://github.com/Leffell-Space/LightAPRS-Code/security/code-scanning/1)

To fix this, define an explicit `permissions` block with least privilege for this workflow.  
Best approach here: add a workflow-level permissions block right after the trigger section (`on:`), setting:

- `contents: read`

This preserves existing functionality (checkout + lint) while restricting `GITHUB_TOKEN` access. No imports, methods, or dependencies are needed since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
